### PR TITLE
gx: update go-libp2p-routing

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.3.0: QmSFHnkFwayfnRKK1Z8jBUauMYMkHrZpQyvbxkFoPYb1VQ
+0.3.1: QmQtviDP8gJyvj4e5GWjZUYbmEGdTrdZ1cYJ3ZJzieGKY2

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
       "version": "2.0.0"
     },
     {
-      "hash": "QmaJ6QDUh7JKPPToaUZ4EtUsPBdrbSAG6zMTkzfEvZgz2j",
+      "hash": "QmaM261ArNTmKMybV4LKy68JTZrf5CkCbRGDxsZwYHgqDS",
       "name": "go-libp2p-routing",
-      "version": "2.6.0"
+      "version": "2.6.1"
     },
     {
       "author": "hashicorp",
@@ -60,6 +60,6 @@
   "license": "MIT",
   "name": "go-libp2p-routing-helpers",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.3.0"
+  "version": "0.3.1"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-kad-dht/pull/199
- https://github.com/ipfs/go-ipfs-routing/pull/14


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace