### PR TITLE
Use validator in SearchValue

### DIFF
--- a/bootstrap_test.go
+++ b/bootstrap_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	errwrap "github.com/hashicorp/errwrap"
+	routing "github.com/libp2p/go-libp2p-routing"
 )
 
 type bootstrapRouter struct {
@@ -20,57 +21,63 @@ func (bs *bootstrapRouter) Bootstrap(ctx context.Context) error {
 func TestBootstrap(t *testing.T) {
 	pings := make([]bool, 6)
 	d := Parallel{
-		Tiered{
-			&bootstrapRouter{
-				bs: func() error {
-					pings[0] = true
-					return nil
+		Routers: []routing.IpfsRouting{
+			Tiered{
+				Routers: []routing.IpfsRouting{
+					&bootstrapRouter{
+						bs: func() error {
+							pings[0] = true
+							return nil
+						},
+					},
 				},
 			},
-		},
-		Tiered{
-			&bootstrapRouter{
-				bs: func() error {
-					pings[1] = true
-					return nil
+			Tiered{
+				Routers: []routing.IpfsRouting{
+					&bootstrapRouter{
+						bs: func() error {
+							pings[1] = true
+							return nil
+						},
+					},
+					&bootstrapRouter{
+						bs: func() error {
+							pings[2] = true
+							return nil
+						},
+					},
 				},
 			},
-			&bootstrapRouter{
-				bs: func() error {
-					pings[2] = true
-					return nil
+			&Compose{
+				ValueStore: &LimitedValueStore{
+					ValueStore: &bootstrapRouter{
+						bs: func() error {
+							pings[3] = true
+							return nil
+						},
+					},
+					Namespaces: []string{"allow1", "allow2", "notsupported", "error"},
 				},
 			},
-		},
-		&Compose{
-			ValueStore: &LimitedValueStore{
-				ValueStore: &bootstrapRouter{
+			&Compose{
+				ValueStore: &LimitedValueStore{
+					ValueStore: &dummyValueStore{},
+				},
+			},
+			Null{},
+			&Compose{},
+			&Compose{
+				ContentRouting: &bootstrapRouter{
 					bs: func() error {
-						pings[3] = true
+						pings[4] = true
 						return nil
 					},
 				},
-				Namespaces: []string{"allow1", "allow2", "notsupported", "error"},
-			},
-		},
-		&Compose{
-			ValueStore: &LimitedValueStore{
-				ValueStore: &dummyValueStore{},
-			},
-		},
-		Null{},
-		&Compose{},
-		&Compose{
-			ContentRouting: &bootstrapRouter{
-				bs: func() error {
-					pings[4] = true
-					return nil
-				},
-			},
-			PeerRouting: &bootstrapRouter{
-				bs: func() error {
-					pings[5] = true
-					return nil
+				PeerRouting: &bootstrapRouter{
+					bs: func() error {
+						pings[5] = true
+						return nil
+					},
 				},
 			},
 		},
@@ -88,48 +95,54 @@ func TestBootstrap(t *testing.T) {
 }
 func TestBootstrapErr(t *testing.T) {
 	d := Parallel{
-		Tiered{
-			&bootstrapRouter{
-				bs: func() error {
-					return errors.New("err1")
-				},
-			},
-		},
-		Tiered{
-			&bootstrapRouter{
-				bs: func() error {
-					return nil
-				},
-			},
-			&bootstrapRouter{
-				bs: func() error {
-					return nil
-				},
-			},
-		},
-		&Compose{
-			ValueStore: &LimitedValueStore{
-				ValueStore: &bootstrapRouter{
-					bs: func() error {
-						return errors.New("err2")
+		Routers: []routing.IpfsRouting{
+			Tiered{
+				Routers: []routing.IpfsRouting{
+					&bootstrapRouter{
+						bs: func() error {
+							return errors.New("err1")
+						},
 					},
 				},
-				Namespaces: []string{"allow1", "allow2", "notsupported", "error"},
 			},
-		},
-		&Compose{
-			ValueStore: &bootstrapRouter{
-				bs: func() error {
-					return errors.New("err3")
+			Tiered{
+				Routers: []routing.IpfsRouting{
+					&bootstrapRouter{
+						bs: func() error {
+							return nil
+						},
+					},
+					&bootstrapRouter{
+						bs: func() error {
+							return nil
+						},
+					},
 				},
 			},
-			ContentRouting: &bootstrapRouter{
-				bs: func() error {
-					return errors.New("err4")
+			&Compose{
+				ValueStore: &LimitedValueStore{
+					ValueStore: &bootstrapRouter{
+						bs: func() error {
+							return errors.New("err2")
+						},
+					},
+					Namespaces: []string{"allow1", "allow2", "notsupported", "error"},
 				},
 			},
+			&Compose{
+				ValueStore: &bootstrapRouter{
+					bs: func() error {
+						return errors.New("err3")
+					},
+				},
+				ContentRouting: &bootstrapRouter{
+					bs: func() error {
+						return errors.New("err4")
+					},
+				},
+			},
+			Null{},
 		},
-		Null{},
 	}
 	ctx := context.Background()
 	err := d.Bootstrap(ctx)

--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
       "hash": "QmfGQp6VVqdPCDyzEM6EGwMY74YPabTSEoQWHUxZuCSWj3",
       "name": "go-multierror",
       "version": "0.1.0"
+    },
+    {
+      "hash": "QmSb4B8ZAAj5ALe9LjfzPyF8Ma6ezC1NTnDF2JQPUJxEXb",
+      "name": "go-libp2p-record",
+      "version": "4.1.7"
     }
   ],
   "gxVersion": "0.12.1",

--- a/parallel.go
+++ b/parallel.go
@@ -5,18 +5,21 @@ import (
 	"reflect"
 	"sync"
 
-	routing "github.com/libp2p/go-libp2p-routing"
-	ropts "github.com/libp2p/go-libp2p-routing/options"
-
 	multierror "github.com/hashicorp/go-multierror"
 	cid "github.com/ipfs/go-cid"
 	ci "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
+	record "github.com/libp2p/go-libp2p-record"
+	routing "github.com/libp2p/go-libp2p-routing"
+	ropts "github.com/libp2p/go-libp2p-routing/options"
 )
 
 // Parallel operates on the slice of routers in parallel.
-type Parallel []routing.IpfsRouting
+type Parallel struct {
+	Routers   []routing.IpfsRouting
+	Validator record.Validator
+}
 
 // Helper function that sees through router composition to avoid unnecessary
 // go routines.
@@ -27,14 +30,14 @@ func supportsKey(vs routing.ValueStore, key string) bool {
 	case *Compose:
 		return vs.ValueStore != nil && supportsKey(vs.ValueStore, key)
 	case Parallel:
-		for _, ri := range vs {
+		for _, ri := range vs.Routers {
 			if supportsKey(ri, key) {
 				return true
 			}
 		}
 		return false
 	case Tiered:
-		for _, ri := range vs {
+		for _, ri := range vs.Routers {
 			if supportsKey(ri, key) {
 				return true
 			}
@@ -54,14 +57,14 @@ func supportsPeer(vs routing.PeerRouting) bool {
 	case *Compose:
 		return vs.PeerRouting != nil && supportsPeer(vs.PeerRouting)
 	case Parallel:
-		for _, ri := range vs {
+		for _, ri := range vs.Routers {
 			if supportsPeer(ri) {
 				return true
 			}
 		}
 		return false
 	case Tiered:
-		for _, ri := range vs {
+		for _, ri := range vs.Routers {
 			if supportsPeer(ri) {
 				return true
 			}
@@ -79,14 +82,14 @@ func supportsContent(vs routing.ContentRouting) bool {
 	case *Compose:
 		return vs.ContentRouting != nil && supportsContent(vs.ContentRouting)
 	case Parallel:
-		for _, ri := range vs {
+		for _, ri := range vs.Routers {
 			if supportsContent(ri) {
 				return true
 			}
 		}
 		return false
 	case Tiered:
-		for _, ri := range vs {
+		for _, ri := range vs.Routers {
 			if supportsContent(ri) {
 				return true
 			}
@@ -98,27 +101,27 @@ func supportsContent(vs routing.ContentRouting) bool {
 }
 
 func (r Parallel) filter(filter func(routing.IpfsRouting) bool) Parallel {
-	cpy := make(Parallel, 0, len(r))
-	for _, ri := range r {
+	cpy := make([]routing.IpfsRouting, 0, len(r.Routers))
+	for _, ri := range r.Routers {
 		if filter(ri) {
 			cpy = append(cpy, ri)
 		}
 	}
-	return cpy
+	return Parallel{Routers: cpy, Validator: r.Validator}
 }
 
 func (r Parallel) put(do func(routing.IpfsRouting) error) error {
-	switch len(r) {
+	switch len(r.Routers) {
 	case 0:
 		return routing.ErrNotSupported
 	case 1:
-		return do(r[0])
+		return do(r.Routers[0])
 	}
 
 	var wg sync.WaitGroup
-	results := make([]error, len(r))
-	wg.Add(len(r))
-	for i, ri := range r {
+	results := make([]error, len(r.Routers))
+	wg.Add(len(r.Routers))
+	for i, ri := range r.Routers {
 		go func(ri routing.IpfsRouting, i int) {
 			results[i] = do(ri)
 			wg.Done()
@@ -149,18 +152,18 @@ func (r Parallel) put(do func(routing.IpfsRouting) error) error {
 }
 
 func (r Parallel) search(ctx context.Context, do func(routing.IpfsRouting) (<-chan []byte, error)) (<-chan []byte, error) {
-	switch len(r) {
+	switch len(r.Routers) {
 	case 0:
 		return nil, routing.ErrNotFound
 	case 1:
-		return do(r[0])
+		return do(r.Routers[0])
 	}
 
 	out := make(chan []byte)
 	var errs []error
 	var wg sync.WaitGroup
 
-	for _, ri := range r {
+	for _, ri := range r.Routers {
 		vchan, err := do(ri)
 		switch err {
 		case nil:
@@ -201,11 +204,11 @@ func (r Parallel) search(ctx context.Context, do func(routing.IpfsRouting) (<-ch
 }
 
 func (r Parallel) get(ctx context.Context, do func(routing.IpfsRouting) (interface{}, error)) (interface{}, error) {
-	switch len(r) {
+	switch len(r.Routers) {
 	case 0:
 		return nil, routing.ErrNotFound
 	case 1:
-		return do(r[0])
+		return do(r.Routers[0])
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -215,7 +218,7 @@ func (r Parallel) get(ctx context.Context, do func(routing.IpfsRouting) (interfa
 		val interface{}
 		err error
 	})
-	for _, ri := range r {
+	for _, ri := range r.Routers {
 		go func(ri routing.IpfsRouting) {
 			value, err := do(ri)
 			select {
@@ -232,7 +235,7 @@ func (r Parallel) get(ctx context.Context, do func(routing.IpfsRouting) (interfa
 	}
 
 	var errs []error
-	for range r {
+	for range r.Routers {
 		select {
 		case res := <-results:
 			switch res.err {
@@ -286,7 +289,36 @@ func (r Parallel) SearchValue(ctx context.Context, key string, opts ...ropts.Opt
 	resCh, err := r.forKey(key).search(ctx, func(ri routing.IpfsRouting) (<-chan []byte, error) {
 		return ri.SearchValue(ctx, key, opts...)
 	})
-	return resCh, err
+
+	valid := make(chan []byte)
+	var best []byte
+	go func() {
+		defer close(valid)
+
+		for v := range resCh {
+			if best == nil {
+				if r.Validator.Validate(key, v) != nil {
+					continue
+				}
+			} else {
+				n, err := r.Validator.Select(key, [][]byte{best, v})
+				if err != nil {
+					continue
+				}
+				if n != 1 {
+					continue
+				}
+			}
+			best = v
+			select {
+			case valid <- v:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return valid, err
 }
 
 func (r Parallel) GetPublicKey(ctx context.Context, p peer.ID) (ci.PubKey, error) {
@@ -322,21 +354,21 @@ func (r Parallel) FindProvidersAsync(ctx context.Context, c cid.Cid, count int) 
 		return supportsContent(ri)
 	})
 
-	switch len(routers) {
+	switch len(routers.Routers) {
 	case 0:
 		ch := make(chan pstore.PeerInfo)
 		close(ch)
 		return ch
 	case 1:
-		return routers[0].FindProvidersAsync(ctx, c, count)
+		return routers.Routers[0].FindProvidersAsync(ctx, c, count)
 	}
 
 	out := make(chan pstore.PeerInfo)
 
 	ctx, cancel := context.WithCancel(ctx)
 
-	providers := make([]<-chan pstore.PeerInfo, len(routers))
-	for i, ri := range routers {
+	providers := make([]<-chan pstore.PeerInfo, len(routers.Routers))
+	for i, ri := range routers.Routers {
 		providers[i] = ri.FindProvidersAsync(ctx, c, count)
 	}
 
@@ -445,7 +477,7 @@ func fewProviders(ctx context.Context, out chan<- pstore.PeerInfo, in []<-chan p
 
 func (r Parallel) Bootstrap(ctx context.Context) error {
 	var me multierror.Error
-	for _, b := range r {
+	for _, b := range r.Routers {
 		if err := b.Bootstrap(ctx); err != nil {
 			me.Errors = append(me.Errors, err)
 		}
@@ -453,4 +485,4 @@ func (r Parallel) Bootstrap(ctx context.Context) error {
 	return me.ErrorOrNil()
 }
 
-var _ routing.IpfsRouting = (Parallel)(nil)
+var _ routing.IpfsRouting = Parallel{}

--- a/parallel.go
+++ b/parallel.go
@@ -1,6 +1,7 @@
 package routinghelpers
 
 import (
+	"bytes"
 	"context"
 	"reflect"
 	"sync"
@@ -309,6 +310,10 @@ func (r Parallel) SearchValue(ctx context.Context, key string, opts ...ropts.Opt
 					continue
 				}
 			}
+			if bytes.Equal(best, v) && len(v) != 0 {
+				continue
+			}
+
 			best = v
 			select {
 			case valid <- v:

--- a/parallel.go
+++ b/parallel.go
@@ -175,8 +175,11 @@ func (r Parallel) search(ctx context.Context, do func(routing.IpfsRouting) (<-ch
 			defer wg.Done()
 			for {
 				select {
-				case v := <-vchan:
-					//TODO: run validator.Select here
+				case v, ok := <-vchan:
+					if !ok {
+						return
+					}
+
 					select {
 					case out <- v:
 					case <-ctx.Done():

--- a/parallel.go
+++ b/parallel.go
@@ -290,6 +290,9 @@ func (r Parallel) SearchValue(ctx context.Context, key string, opts ...ropts.Opt
 	resCh, err := r.forKey(key).search(ctx, func(ri routing.IpfsRouting) (<-chan []byte, error) {
 		return ri.SearchValue(ctx, key, opts...)
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	valid := make(chan []byte)
 	var best []byte
@@ -297,11 +300,7 @@ func (r Parallel) SearchValue(ctx context.Context, key string, opts ...ropts.Opt
 		defer close(valid)
 
 		for v := range resCh {
-			if best == nil {
-				if r.Validator.Validate(key, v) != nil {
-					continue
-				}
-			} else {
+			if best != nil {
 				n, err := r.Validator.Select(key, [][]byte{best, v})
 				if err != nil {
 					continue

--- a/pubkey_test.go
+++ b/pubkey_test.go
@@ -10,30 +10,36 @@ import (
 
 func TestGetPublicKey(t *testing.T) {
 	d := Parallel{
-		Parallel{
+		Routers: []routing.IpfsRouting{
+			Parallel{
+				Routers: []routing.IpfsRouting{
+					&Compose{
+						ValueStore: &LimitedValueStore{
+							ValueStore: new(dummyValueStore),
+							Namespaces: []string{"other"},
+						},
+					},
+				},
+			},
+			Tiered{
+				Routers: []routing.IpfsRouting{
+					&Compose{
+						ValueStore: &LimitedValueStore{
+							ValueStore: new(dummyValueStore),
+							Namespaces: []string{"pk"},
+						},
+					},
+				},
+			},
 			&Compose{
 				ValueStore: &LimitedValueStore{
 					ValueStore: new(dummyValueStore),
-					Namespaces: []string{"other"},
+					Namespaces: []string{"other", "pk"},
 				},
 			},
+			&struct{ Compose }{Compose{ValueStore: &LimitedValueStore{ValueStore: Null{}}}},
+			&struct{ Compose }{},
 		},
-		Tiered{
-			&Compose{
-				ValueStore: &LimitedValueStore{
-					ValueStore: new(dummyValueStore),
-					Namespaces: []string{"pk"},
-				},
-			},
-		},
-		&Compose{
-			ValueStore: &LimitedValueStore{
-				ValueStore: new(dummyValueStore),
-				Namespaces: []string{"other", "pk"},
-			},
-		},
-		&struct{ Compose }{Compose{ValueStore: &LimitedValueStore{ValueStore: Null{}}}},
-		&struct{ Compose }{},
 	}
 
 	pid, _ := peert.RandPeerID()

--- a/tiered.go
+++ b/tiered.go
@@ -11,19 +11,23 @@ import (
 	ci "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
+	record "github.com/libp2p/go-libp2p-record"
 )
 
 // Tiered is like the Parallel except that GetValue and FindPeer
 // are called in series.
-type Tiered []routing.IpfsRouting
+type Tiered struct {
+	Routers   []routing.IpfsRouting
+	Validator record.Validator
+}
 
 func (r Tiered) PutValue(ctx context.Context, key string, value []byte, opts ...ropts.Option) error {
-	return Parallel(r).PutValue(ctx, key, value, opts...)
+	return Parallel{Routers: r.Routers}.PutValue(ctx, key, value, opts...)
 }
 
 func (r Tiered) get(ctx context.Context, do func(routing.IpfsRouting) (interface{}, error)) (interface{}, error) {
 	var errs []error
-	for _, ri := range r {
+	for _, ri := range r.Routers {
 		val, err := do(ri)
 		switch err {
 		case nil:
@@ -55,7 +59,7 @@ func (r Tiered) GetValue(ctx context.Context, key string, opts ...ropts.Option) 
 }
 
 func (r Tiered) SearchValue(ctx context.Context, key string, opts ...ropts.Option) (<-chan []byte, error) {
-	return Parallel(r).SearchValue(ctx, key, opts...)
+	return Parallel{Routers: r.Routers, Validator: r.Validator}.SearchValue(ctx, key, opts...)
 }
 
 func (r Tiered) GetPublicKey(ctx context.Context, p peer.ID) (ci.PubKey, error) {
@@ -67,11 +71,11 @@ func (r Tiered) GetPublicKey(ctx context.Context, p peer.ID) (ci.PubKey, error) 
 }
 
 func (r Tiered) Provide(ctx context.Context, c cid.Cid, local bool) error {
-	return Parallel(r).Provide(ctx, c, local)
+	return Parallel{Routers: r.Routers}.Provide(ctx, c, local)
 }
 
 func (r Tiered) FindProvidersAsync(ctx context.Context, c cid.Cid, count int) <-chan pstore.PeerInfo {
-	return Parallel(r).FindProvidersAsync(ctx, c, count)
+	return Parallel{Routers: r.Routers}.FindProvidersAsync(ctx, c, count)
 }
 
 func (r Tiered) FindPeer(ctx context.Context, p peer.ID) (pstore.PeerInfo, error) {
@@ -83,7 +87,7 @@ func (r Tiered) FindPeer(ctx context.Context, p peer.ID) (pstore.PeerInfo, error
 }
 
 func (r Tiered) Bootstrap(ctx context.Context) error {
-	return Parallel(r).Bootstrap(ctx)
+	return Parallel{Routers: r.Routers}.Bootstrap(ctx)
 }
 
-var _ routing.IpfsRouting = (Tiered)(nil)
+var _ routing.IpfsRouting = Tiered{}

--- a/tiered_test.go
+++ b/tiered_test.go
@@ -11,36 +11,38 @@ import (
 
 func TestTieredGet(t *testing.T) {
 	d := Tiered{
-		Null{},
-		&Compose{
-			ValueStore:     new(dummyValueStore),
-			ContentRouting: Null{},
-			PeerRouting:    Null{},
+		Routers: []routing.IpfsRouting{
+			Null{},
+			&Compose{
+				ValueStore:     new(dummyValueStore),
+				ContentRouting: Null{},
+				PeerRouting:    Null{},
+			},
+			&Compose{
+				ValueStore:     new(dummyValueStore),
+				ContentRouting: Null{},
+				PeerRouting:    Null{},
+			},
+			&Compose{
+				ValueStore:     new(dummyValueStore),
+				ContentRouting: Null{},
+				PeerRouting:    Null{},
+			},
+			Null{},
+			&Compose{},
 		},
-		&Compose{
-			ValueStore:     new(dummyValueStore),
-			ContentRouting: Null{},
-			PeerRouting:    Null{},
-		},
-		&Compose{
-			ValueStore:     new(dummyValueStore),
-			ContentRouting: Null{},
-			PeerRouting:    Null{},
-		},
-		Null{},
-		&Compose{},
 	}
 	ctx := context.Background()
-	if err := d[1].PutValue(ctx, "k1", []byte("v1")); err != nil {
+	if err := d.Routers[1].PutValue(ctx, "k1", []byte("v1")); err != nil {
 		t.Fatal(err)
 	}
-	if err := d[2].PutValue(ctx, "k2", []byte("v2")); err != nil {
+	if err := d.Routers[2].PutValue(ctx, "k2", []byte("v2")); err != nil {
 		t.Fatal(err)
 	}
-	if err := d[2].PutValue(ctx, "k1", []byte("v1shadow")); err != nil {
+	if err := d.Routers[2].PutValue(ctx, "k1", []byte("v1shadow")); err != nil {
 		t.Fatal(err)
 	}
-	if err := d[3].PutValue(ctx, "k3", []byte("v3")); err != nil {
+	if err := d.Routers[3].PutValue(ctx, "k3", []byte("v3")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -69,11 +71,11 @@ func TestTieredGet(t *testing.T) {
 		t.Fatalf("expected error to contain myErr, got: %s", err)
 	}
 
-	if _, err := (Tiered{d[1]}).GetValue(ctx, "/error/myErr"); !errwrap.Contains(err, "myErr") {
+	if _, err := (Tiered{Routers: []routing.IpfsRouting{d.Routers[1]}}).GetValue(ctx, "/error/myErr"); !errwrap.Contains(err, "myErr") {
 		t.Fatalf("expected error to contain myErr, got: %s", err)
 	}
 
-	for _, di := range append([]routing.IpfsRouting{d}, d[1:len(d)-2]...) {
+	for _, di := range append([]routing.IpfsRouting{d}, d.Routers[1:len(d.Routers)-2]...) {
 		v, err := di.GetValue(ctx, "key")
 		if err != nil {
 			t.Fatal(err)
@@ -85,7 +87,7 @@ func TestTieredGet(t *testing.T) {
 }
 
 func TestTieredNoSupport(t *testing.T) {
-	d := Tiered{Tiered{Null{}}}
+	d := Tiered{Routers: []routing.IpfsRouting{Tiered{Routers: []routing.IpfsRouting{Null{}}}}}
 	if _, ok := <-d.FindProvidersAsync(context.Background(), cid.Cid{}, 0); ok {
 		t.Fatal("shouldn't have found a provider")
 	}


### PR DESCRIPTION
This is actually a small patch, bulk of the changes is caused by changing the `Parallel` and `Tiered` types.

Only real changes are in `parallel.go`:
* Properly closing channel in `search`
* Using validator in `SearchValue`
* Not re-emitting already seen values