### PR TITLE
Stop parallel search after first successful chan closes

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.3.3: QmdrhAjJKSqpykiqkZt7CyVXUyy3R9W4ptmiW49MCWXLeG
+0.3.4: QmcRdSdYkL17qhuQAibF5D14XdQ1iunvaVnXGjDiQTdRm9

--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
   "license": "MIT",
   "name": "go-libp2p-routing-helpers",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.3.3"
+  "version": "0.3.4"
 }
 

--- a/tiered_test.go
+++ b/tiered_test.go
@@ -102,22 +102,19 @@ func TestTieredSearch(t *testing.T) {
 	if !ok {
 		t.Fatal("expected to get a value")
 	}
-	if string(v) != "v1 - 1" {
-		t.Fatalf("unexpected value: %s", string(v))
-	}
 
 	v, ok = <-valch
-	if !ok {
-		t.Fatal("expected to get a value")
-	}
-	if string(v) != "v1 - 2" {
-		t.Fatalf("unexpected value: %s", string(v))
+	if ok {
+		if string(v) != "v1 - 2" {
+			t.Fatalf("unexpected value: %s", string(v))
+		}
+
+		_, ok = <-valch
+		if ok {
+			t.Fatal("didn't expect a value")
+		}
 	}
 
-	_, ok = <-valch
-	if ok {
-		t.Fatal("didn't expect a value")
-	}
 }
 
 func TestTieredGet(t *testing.T) {


### PR DESCRIPTION
See https://github.com/ipfs/go-ipfs/pull/5404#issuecomment-424692953 / https://github.com/libp2p/go-libp2p-routing/pull/29