### PR TITLE
WIP: Changes to reflect the fact that Provide/FindProviders now use multhases.

### DIFF
--- a/composed.go
+++ b/composed.go
@@ -4,12 +4,12 @@ import (
 	"context"
 
 	multierror "github.com/hashicorp/go-multierror"
-	cid "github.com/ipfs/go-cid"
 	ci "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
 	routing "github.com/libp2p/go-libp2p-routing"
 	ropts "github.com/libp2p/go-libp2p-routing/options"
+	mh "github.com/multiformats/go-multihash"
 )
 
 // Compose composes the components into a single router. Not specifying a
@@ -47,7 +47,7 @@ func (cr *Compose) GetValue(ctx context.Context, key string, opts ...ropts.Optio
 // Provide adds the given cid to the content routing system. If 'true' is
 // passed, it also announces it, otherwise it is just kept in the local
 // accounting of which objects are being provided.
-func (cr *Compose) Provide(ctx context.Context, c cid.Cid, local bool) error {
+func (cr *Compose) Provide(ctx context.Context, c mh.Multihash, local bool) error {
 	if cr.ContentRouting == nil {
 		return routing.ErrNotSupported
 	}
@@ -55,7 +55,7 @@ func (cr *Compose) Provide(ctx context.Context, c cid.Cid, local bool) error {
 }
 
 // FindProvidersAsync searches for peers who are able to provide a given key
-func (cr *Compose) FindProvidersAsync(ctx context.Context, c cid.Cid, count int) <-chan pstore.PeerInfo {
+func (cr *Compose) FindProvidersAsync(ctx context.Context, c mh.Multihash, count int) <-chan pstore.PeerInfo {
 	if cr.ContentRouting == nil {
 		ch := make(chan pstore.PeerInfo)
 		close(ch)

--- a/null.go
+++ b/null.go
@@ -6,7 +6,7 @@ import (
 	routing "github.com/libp2p/go-libp2p-routing"
 	ropts "github.com/libp2p/go-libp2p-routing/options"
 
-	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
 	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
 )
@@ -25,12 +25,12 @@ func (nr Null) GetValue(context.Context, string, ...ropts.Option) ([]byte, error
 }
 
 // Provide always returns ErrNotSupported
-func (nr Null) Provide(context.Context, cid.Cid, bool) error {
+func (nr Null) Provide(context.Context, mh.Multihash, bool) error {
 	return routing.ErrNotSupported
 }
 
 // FindProvidersAsync always returns a closed channel
-func (nr Null) FindProvidersAsync(context.Context, cid.Cid, int) <-chan pstore.PeerInfo {
+func (nr Null) FindProvidersAsync(context.Context, mh.Multihash, int) <-chan pstore.PeerInfo {
 	ch := make(chan pstore.PeerInfo)
 	close(ch)
 	return ch

--- a/parallel.go
+++ b/parallel.go
@@ -9,10 +9,10 @@ import (
 	ropts "github.com/libp2p/go-libp2p-routing/options"
 
 	multierror "github.com/hashicorp/go-multierror"
-	cid "github.com/ipfs/go-cid"
 	ci "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
+	mh "github.com/multiformats/go-multihash"
 )
 
 // Parallel operates on the slice of routers in parallel.
@@ -250,7 +250,7 @@ func (r Parallel) FindPeer(ctx context.Context, p peer.ID) (pstore.PeerInfo, err
 	return pi, err
 }
 
-func (r Parallel) Provide(ctx context.Context, c cid.Cid, local bool) error {
+func (r Parallel) Provide(ctx context.Context, c mh.Multihash, local bool) error {
 	return r.filter(func(ri routing.IpfsRouting) bool {
 		return supportsContent(ri)
 	}).put(func(ri routing.IpfsRouting) error {
@@ -258,7 +258,7 @@ func (r Parallel) Provide(ctx context.Context, c cid.Cid, local bool) error {
 	})
 }
 
-func (r Parallel) FindProvidersAsync(ctx context.Context, c cid.Cid, count int) <-chan pstore.PeerInfo {
+func (r Parallel) FindProvidersAsync(ctx context.Context, c mh.Multihash, count int) <-chan pstore.PeerInfo {
 	routers := r.filter(func(ri routing.IpfsRouting) bool {
 		return supportsContent(ri)
 	})

--- a/tiered.go
+++ b/tiered.go
@@ -7,10 +7,10 @@ import (
 	ropts "github.com/libp2p/go-libp2p-routing/options"
 
 	multierror "github.com/hashicorp/go-multierror"
-	cid "github.com/ipfs/go-cid"
 	ci "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
+	mh "github.com/multiformats/go-multihash"
 )
 
 // Tiered is like the Parallel except that GetValue and FindPeer
@@ -62,11 +62,11 @@ func (r Tiered) GetPublicKey(ctx context.Context, p peer.ID) (ci.PubKey, error) 
 	return val, err
 }
 
-func (r Tiered) Provide(ctx context.Context, c cid.Cid, local bool) error {
+func (r Tiered) Provide(ctx context.Context, c mh.Multihash, local bool) error {
 	return Parallel(r).Provide(ctx, c, local)
 }
 
-func (r Tiered) FindProvidersAsync(ctx context.Context, c cid.Cid, count int) <-chan pstore.PeerInfo {
+func (r Tiered) FindProvidersAsync(ctx context.Context, c mh.Multihash, count int) <-chan pstore.PeerInfo {
 	return Parallel(r).FindProvidersAsync(ctx, c, count)
 }
 


### PR DESCRIPTION
See https://github.com/libp2p/go-libp2p-routing/pull/33
