### PR TITLE
fix(put): fail if any router fails

### DIFF
--- a/dummy_test.go
+++ b/dummy_test.go
@@ -13,6 +13,21 @@ import (
 	ropts "github.com/libp2p/go-libp2p-routing/options"
 )
 
+type failValueStore struct{}
+
+var failValueErr = errors.New("fail valuestore error")
+
+func (f failValueStore) PutValue(ctx context.Context, key string, value []byte, opts ...ropts.Option) error {
+	return failValueErr
+}
+func (f failValueStore) GetValue(ctx context.Context, key string, opts ...ropts.Option) ([]byte, error) {
+	return nil, failValueErr
+}
+
+func (f failValueStore) SearchValue(ctx context.Context, key string, opts ...ropts.Option) (<-chan []byte, error) {
+	return nil, failValueErr
+}
+
 type dummyValueStore sync.Map
 
 func (d *dummyValueStore) PutValue(ctx context.Context, key string, value []byte, opts ...ropts.Option) error {

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -129,6 +129,24 @@ func TestParallelPutGet(t *testing.T) {
 	cancel()
 }
 
+func TestParallelPutFailure(t *testing.T) {
+	ctx := context.Background()
+	router := Parallel{
+		Routers: []routing.IpfsRouting{
+			&Compose{
+				ValueStore: new(failValueStore),
+			},
+			&Compose{
+				ValueStore: new(dummyValueStore),
+			},
+		},
+	}
+	err := router.PutValue(ctx, "/some/thing", []byte("thing"))
+	if err != failValueErr {
+		t.Fatalf("exected put to fail with %q, got %q", failValueErr, err)
+	}
+}
+
 func TestBasicParallelFindProviders(t *testing.T) {
 	prefix := cid.NewPrefixV1(cid.Raw, mh.SHA2_256)
 	c, _ := prefix.Sum([]byte("foo"))


### PR DESCRIPTION
That way, we don't succeed if, e.g., publishing to pubsub succeeds but the DHT
fails.