### PR TITLE
readme: replace IPFS contrib links with libp2p

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ See https://godoc.org/github.com/libp2p/go-libp2p-routing-helpers.
 
 Feel free to join in. All welcome. Open an [issue](https://github.com/libp2p/go-libp2p-routing-helpers/issues)!
 
-This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+This repository falls under the libp2p [Code of Conduct](https://github.com/libp2p/community/blob/master/code-of-conduct.md).
 
-### Want to hack on IPFS?
+### Want to hack on libp2p?
 
-[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/contributing.md)
+[![](https://cdn.rawgit.com/libp2p/community/master/img/contribute.gif)](https://github.com/libp2p/community/blob/master/CONTRIBUTE.md)
 
 ## License
 


### PR DESCRIPTION
This is one of several PRs to replace the "contribute to IPFS" links and images in libp2p READMEs with their libp2p equivalent.