### PR TITLE
limit QueryEvent errors

### DIFF
--- a/parallel.go
+++ b/parallel.go
@@ -329,21 +329,22 @@ func (r Parallel) mergeQueryEvents(ctx context.Context) (context.Context, contex
 // puts to terminate.
 func (r Parallel) PutValue(ctx context.Context, key string, value []byte, opts ...routing.Option) error {
 	reqCtx, cancel := r.mergeQueryEvents(ctx)
-	defer cancel()
-	return r.forKey(key).put(func(ri routing.Routing) error {
+	err := r.forKey(key).put(func(ri routing.Routing) error {
 		return ri.PutValue(reqCtx, key, value, opts...)
 	})
+	cancel()
+	return err
 }
 
 // GetValue searches all sub-routers for the given key, returning the result
 // from the first sub-router to complete the query.
 func (r Parallel) GetValue(ctx context.Context, key string, opts ...routing.Option) ([]byte, error) {
 	reqCtx, cancel := r.mergeQueryEvents(ctx)
-	defer cancel()
 	vInt, err := r.forKey(key).get(reqCtx, func(ri routing.Routing) (interface{}, error) {
 		return ri.GetValue(reqCtx, key, opts...)
 	})
 	val, _ := vInt.([]byte)
+	cancel()
 	return val, err
 }
 
@@ -387,6 +388,7 @@ func (r Parallel) SearchValue(ctx context.Context, key string, opts ...routing.O
 				return
 			}
 		}
+		cancel()
 	}()
 
 	return valid, err
@@ -408,13 +410,13 @@ func (r Parallel) GetPublicKey(ctx context.Context, p peer.ID) (ci.PubKey, error
 // first result.
 func (r Parallel) FindPeer(ctx context.Context, p peer.ID) (peer.AddrInfo, error) {
 	reqCtx, cancel := r.mergeQueryEvents(ctx)
-	defer cancel()
 	vInt, err := r.filter(func(ri routing.Routing) bool {
 		return supportsPeer(ri)
 	}).get(ctx, func(ri routing.Routing) (interface{}, error) {
 		return ri.FindPeer(reqCtx, p)
 	})
 	pi, _ := vInt.(peer.AddrInfo)
+	cancel()
 	return pi, err
 }
 
@@ -462,13 +464,13 @@ func (r Parallel) FindProvidersAsync(ctx context.Context, c cid.Cid, count int) 
 	}
 
 	go func() {
-		defer cancel()
 		defer close(out)
 		if len(providers) > 8 {
 			manyProviders(reqCtx, out, providers, count)
 		} else {
 			fewProviders(reqCtx, out, providers, count)
 		}
+		cancel()
 	}()
 	return out
 }

--- a/parallel.go
+++ b/parallel.go
@@ -292,8 +292,8 @@ func (r Parallel) forKey(key string) Parallel {
 // mergeQueryEvents limits `routing.QueryError` events to only be sent on the context in case all parallel
 // routers fail.
 func (r Parallel) mergeQueryEvents(ctx context.Context) (context.Context, context.CancelFunc) {
-	subCtx, evCh := routing.RegisterForQueryEvents(ctx)
-	subCtx, cancel := context.WithCancel(subCtx)
+	subCtx, cancel := context.WithCancel(ctx)
+	subCtx, evCh := routing.RegisterForQueryEvents(subCtx)
 	go func() {
 		var errEvt *routing.QueryEvent
 		successfulEvent := false


### PR DESCRIPTION
Complement to the fix in kad-dht for https://github.com/libp2p/go-libp2p-kad-dht/issues/602

When multiple routers are answering a query, and our logic is that the query has succeeded if at least one of the sub routers find a value, then we shouldn't be emitting 'QueryFailed' errors over the context event channel.