### PR TITLE
fix error handling in Parallel.search

### DIFF
--- a/parallel.go
+++ b/parallel.go
@@ -11,8 +11,8 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/routing"
 
-	multierror "github.com/hashicorp/go-multierror"
-	cid "github.com/ipfs/go-cid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/ipfs/go-cid"
 	record "github.com/libp2p/go-libp2p-record"
 )
 
@@ -171,17 +171,12 @@ func (r Parallel) search(ctx context.Context, do func(routing.Routing) (<-chan [
 	ctx, cancel := context.WithCancel(ctx)
 
 	out := make(chan []byte)
-	var errs []error
 
 	var wg sync.WaitGroup
 	for _, ri := range r.Routers {
 		vchan, err := do(ri)
-		switch err {
-		case nil:
-		case routing.ErrNotFound, routing.ErrNotSupported:
+		if err != nil {
 			continue
-		default:
-			errs = append(errs, err)
 		}
 
 		wg.Add(1)


### PR DESCRIPTION
Found by `staticcheck`.

I'm not sure I understand the original code, it doesn't seem correct to continue if `err != nil`.