### PR TITLE
Return a closed channel instead of nil for getChannelOrErrorParallel

### DIFF
--- a/compparallel.go
+++ b/compparallel.go
@@ -312,11 +312,11 @@ func getChannelOrErrorParallel[T any](
 	select {
 	case err, ok := <-errCh:
 		if !ok {
-			return nil, routing.ErrNotFound
+			return outCh, routing.ErrNotFound
 		}
-		return nil, err
+		return outCh, err
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return outCh, ctx.Err()
 	default:
 		return outCh, nil
 	}


### PR DESCRIPTION
Returning nil causes functions ranging over the channel to block indefinitely but returning a closed channel doesn't. In our specific case, go-bitswap was hanging on it and after a few canceled requests, would no longer reach out to IPFS indexers via go-delegated-routing.

Here's the line that would hang. Discovered via a pprof goroutine dump.
https://github.com/ipfs/go-bitswap/blob/13c89f1ba6c65253a3dfc3b2bafcb1730b320b66/network/ipfs_impl.go#L382

Thanks @Anshul-Birla for extensive help with debugging this.