### PR TITLE
feat: retrieve routers from composable routers

### DIFF
--- a/compconfig.go
+++ b/compconfig.go
@@ -25,3 +25,7 @@ type ProvideManyRouter interface {
 	ProvideMany(ctx context.Context, keys []multihash.Multihash) error
 	Ready() bool
 }
+
+type Composable interface {
+	Routers() []routing.Routing
+}

--- a/compconfig.go
+++ b/compconfig.go
@@ -26,6 +26,6 @@ type ProvideManyRouter interface {
 	Ready() bool
 }
 
-type Composable interface {
+type ComposableRouter interface {
 	Routers() []routing.Routing
 }

--- a/compparallel.go
+++ b/compparallel.go
@@ -19,6 +19,7 @@ var log = logging.Logger("routing/composable")
 
 var _ routing.Routing = &composableParallel{}
 var _ ProvideManyRouter = &composableParallel{}
+var _ Composable = &composableParallel{}
 
 type composableParallel struct {
 	routers []*ParallelRouter
@@ -32,6 +33,15 @@ func NewComposableParallel(routers []*ParallelRouter) *composableParallel {
 	return &composableParallel{
 		routers: routers,
 	}
+}
+
+func (r *composableParallel) Routers() []routing.Routing {
+	var routers []routing.Routing
+	for _, pr := range r.routers {
+		routers = append(routers, pr.Router)
+	}
+
+	return routers
 }
 
 // Provide will call all Routers in parallel.

--- a/compparallel.go
+++ b/compparallel.go
@@ -19,7 +19,7 @@ var log = logging.Logger("routing/composable")
 
 var _ routing.Routing = &composableParallel{}
 var _ ProvideManyRouter = &composableParallel{}
-var _ Composable = &composableParallel{}
+var _ ComposableRouter = &composableParallel{}
 
 type composableParallel struct {
 	routers []*ParallelRouter

--- a/compparallel_test.go
+++ b/compparallel_test.go
@@ -36,6 +36,8 @@ func TestNoResults(t *testing.T) {
 	v, err := cp.GetValue(context.Background(), "a")
 	require.NoError(err)
 	require.Equal("av", string(v))
+
+	require.Equal(2, len(cp.Routers()))
 }
 
 type getValueFixture struct {

--- a/compsequential.go
+++ b/compsequential.go
@@ -13,7 +13,7 @@ import (
 
 var _ routing.Routing = &composableSequential{}
 var _ ProvideManyRouter = &composableSequential{}
-var _ Composable = &composableSequential{}
+var _ ComposableRouter = &composableSequential{}
 
 type composableSequential struct {
 	routers []*SequentialRouter

--- a/compsequential.go
+++ b/compsequential.go
@@ -12,6 +12,8 @@ import (
 )
 
 var _ routing.Routing = &composableSequential{}
+var _ ProvideManyRouter = &composableSequential{}
+var _ Composable = &composableSequential{}
 
 type composableSequential struct {
 	routers []*SequentialRouter
@@ -21,6 +23,15 @@ func NewComposableSequential(routers []*SequentialRouter) *composableSequential 
 	return &composableSequential{
 		routers: routers,
 	}
+}
+
+func (r *composableSequential) Routers() []routing.Routing {
+	var routers []routing.Routing
+	for _, sr := range r.routers {
+		routers = append(routers, sr.Router)
+	}
+
+	return routers
 }
 
 // Provide calls Provide method per each router sequentially.

--- a/compsequential_test.go
+++ b/compsequential_test.go
@@ -12,6 +12,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNoResultsSequential(t *testing.T) {
+	require := require.New(t)
+	rs := []*SequentialRouter{
+		{
+			Timeout:     time.Second,
+			IgnoreError: true,
+			Router:      Null{},
+		},
+		{
+			Timeout:     time.Second,
+			IgnoreError: true,
+			Router: &Compose{
+				ValueStore:     newDummyValueStore(t, []string{"a"}, []string{"av"}),
+				PeerRouting:    Null{},
+				ContentRouting: Null{},
+			},
+		},
+	}
+
+	cs := NewComposableSequential(rs)
+
+	v, err := cs.GetValue(context.Background(), "a")
+	require.NoError(err)
+	require.Equal("av", string(v))
+
+	require.Equal(2, len(cs.Routers()))
+}
+
 func TestComposableSequentialFixtures(t *testing.T) {
 	fixtures := []struct {
 		Name             string


### PR DESCRIPTION
This is useful when you want to access specific features or metrics needed per router, like get DHT stats.

Signed-off-by: Antonio Navarro <antnavper@gmail.com>