### PR TITLE
fix: cancel parallel routers

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.6.0"
+  "version": "v0.6.1"
 }


### PR DESCRIPTION
Fixes a bug where we wait for parallel routers to return a value although we already have one. Before this change, we would have waited for all routers to return a value.

cc @Jorropo 