### PR TITLE
fix: iterate over keys manually in ProvideMany

### DIFF
--- a/compconfig.go
+++ b/compconfig.go
@@ -23,6 +23,9 @@ type SequentialRouter struct {
 
 type ProvideManyRouter interface {
 	ProvideMany(ctx context.Context, keys []multihash.Multihash) error
+}
+
+type ReadyAbleRouter interface {
 	Ready() bool
 }
 

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.6.2"
+  "version": "v0.7.0"
 }


### PR DESCRIPTION
Consumers use type assertions to know if it is safe to send us ProvideMany calls, however we would silently drop them on the floor which is uncool. Fallback to iterating instead.

Something smarter like doing X many concurrent workers might be nice but I feel this needs to go with a bigger DHT refactor and have ProvideMany operations on all router types.