### PR TITLE
fix: handle err with response

### DIFF
--- a/compparallel.go
+++ b/compparallel.go
@@ -231,17 +231,23 @@ func getValueOrErrorParallel[T any](
 				ctx, cancel := withCancelAndOptionalTimeout(ctx, r.Timeout)
 				defer cancel()
 				value, empty, err := f(ctx, r.Router)
-				if err != nil &&
-					!errors.Is(err, routing.ErrNotFound) &&
-					!r.IgnoreError {
-					log.Debug("getValueOrErrorParallel: error calling router function for router ", r.Router,
-						" with timeout ", r.Timeout,
-						" and ignore errors ", r.IgnoreError,
-						" with error ", err,
-					)
-					select {
-					case <-ctx.Done():
-					case errCh <- err:
+				if err != nil {
+					if !errors.Is(err, routing.ErrNotFound) &&
+						!r.IgnoreError {
+						log.Debug("getValueOrErrorParallel: error calling router function for router ", r.Router,
+							" with timeout ", r.Timeout,
+							" and ignore errors ", r.IgnoreError,
+							" with error ", err,
+						)
+						select {
+						case <-ctx.Done():
+						case errCh <- err:
+						}
+					} else {
+						log.Debug("getValueOrErrorParallel: not found or ignorable error for router ", r.Router,
+							" with timeout ", r.Timeout,
+							" and ignore errors ", r.IgnoreError,
+						)
 					}
 					return
 				}

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.7.2"
+  "version": "v0.7.3"
 }


### PR DESCRIPTION
fixes https://github.com/ipfs/kubo/issues/10117

cc @Jorropo another fun bug here where if the response from functions like `FindPeer` is both an error and a value we don't return an error (even if the value is a `peer.AddrInfo` with no addresses). I'm not sure what the intended behavior was here with `IgnoreError`, empty, etc. on functions like `FindPeer`, so please check my work.

Note: you could also argue that the code here should be fine and that the issue is in implementations like https://github.com/libp2p/go-libp2p-kad-dht/blob/b63ad6096833d36b365f1361edab871f6cdc283c/dual/dual.go#L304

Additionally, if preferred (or additionally) we could change:
https://github.com/libp2p/go-libp2p-routing-helpers/blob/71d7c965185ed346e39cc26140ac49ea13b2222f/compparallel.go#L143

to check `addr.ID == "" || len(addr.Addrs) == 0` so that we check more rigorously for an empty result.